### PR TITLE
Recognise OpenJDK 1.8

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -205,7 +205,7 @@
       var java = spawn('java', ['-version']);
 
       java.stderr.on('data', function(data) {
-        var version = _.result(/java version "(.+)"/.exec(data.toString()), 1);
+        var version = _.result(/(?:java|openjdk) version "(.+)"/.exec(data.toString()), 1);
         result = compareVersion(version, JAVA_MIN_VERSION) > -1;
 
         java.stderr.removeAllListeners('data');


### PR DESCRIPTION
OpenJDK 1.8 reports it's version as `openjdk version "1.8.0"` rather than `java version...` like earlier versions.
