### PR TITLE
Add package preferGlobal hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "main": "bin/lodash",
   "bin": { "lodash": "bin/lodash" },
+  "preferGlobal": "true",
   "keywords": "builder, compile, customize, lodash, util",
   "author": "John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)",
   "contributors": [


### PR DESCRIPTION
Just gives users a hint in npm logos `npm install lodash-cli -g` and gives info messages to users installing it non globally.