### PR TITLE
Add .create() to core

### DIFF
--- a/lib/listing.js
+++ b/lib/listing.js
@@ -48,6 +48,7 @@ _.assign(module.exports, {
     'chain',
     'clone',
     'compact',
+    'create',
     'defaults',
     'defer',
     'delay',


### PR DESCRIPTION
This adds ~30 bytes to the build as `baseCreate` is already included in core (don't sweat it's still below 5kb!) 

Anyway this is prompted by `create()` now being used in Backbone master as of https://github.com/jashkenas/backbone/pull/3553.