### PR TITLE
Expose extra functions when `plus` is used with `core`.

### DIFF
--- a/bin/lodash
+++ b/bin/lodash
@@ -2983,7 +2983,7 @@ function build(options, callback) {
 
       // Remove method assignments for non-core methods.
       if (isCore) {
-        _.each(_.difference(buildFuncs, listing.coreFuncs), function(funcName) {
+        _.each(_.difference(buildFuncs, listing.coreFuncs, plusFuncs), function(funcName) {
           source = removeMethodAssignment(source, funcName);
         });
       }


### PR DESCRIPTION
I couldn't find in the documentation whether the use of `core` and `plus` together is supported. It's handy when you just want to add a few functions on top of the core build.
Currently, when you attempt that, the functions get added to the build but do not get exposed. 