### PR TITLE
Add collapse_vars to the Uglify options

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -461,7 +461,8 @@ function uglify(source, label, callback) {
         'negate_iife': false,
         'pure_getters': true,
         'unsafe': true,
-        'warnings': false
+        'warnings': false,
+        'collapse_vars': true
       },
       'output': _.assign({
         'ascii_only': !this.isTemplate,


### PR DESCRIPTION
With this option, Uglify manages to remove (inline) 3 variables in lodash 4.15.0 after Closure compiler in the advanced mode.